### PR TITLE
Adapt to golden file test pattern

### DIFF
--- a/freshservice/_testdata/TestAddChangeNote.data
+++ b/freshservice/_testdata/TestAddChangeNote.data
@@ -1,0 +1,21 @@
+{
+    "status": true,
+    "item": {
+        "note": {
+            "id": 1,
+            "body": "%s",
+            "body_html": "<div>%s</div>",
+            "to_emails": null,
+            "cc_emails": null,
+            "deleted": false,
+            "notable_type": "Itil::Change",
+            "notable_id": 1,
+            "user_id": 1,
+            "account_id": 1,
+            "created_at": "2018-11-16T19:59:33+01:00",
+            "updated_at": "2018-11-16T19:59:33+01:00",
+            "header_info": null
+        }
+    },
+    "redirect": null
+}

--- a/freshservice/_testdata/TestCreateChange.data
+++ b/freshservice/_testdata/TestCreateChange.data
@@ -1,0 +1,51 @@
+{
+    "status": true,
+    "item": {
+        "itil_change": {
+            "id": 1,
+            "display_id": 1,
+            "requester_id": 1,
+            "owner_id": null,
+            "group_id": null,
+            "priority": 1,
+            "impact": 1,
+            "status": 1,
+            "risk": 1,
+            "change_type": 1,
+            "approval_status": 4,
+            "deleted": false,
+            "subject": "change for support",
+            "created_at": "2018-11-01T15:58:49+01:00",
+            "updated_at": "2018-11-01T15:58:49+01:00",
+            "cc_email": {},
+            "planned_start_date": "2018-01-01T01:00:00+01:00",
+            "planned_end_date": "2018-01-01T01:00:00+01:00",
+            "import_id": null,
+            "department_id": null,
+            "email_config_id": null,
+            "project_id": null,
+            "approval_type": null,
+            "wf_event_id": null,
+            "state_flow_id": null,
+            "state_traversal": [
+                1
+            ],
+            "status_name": "Open",
+            "impact_name": "Low",
+            "priority_name": "Low",
+            "requester_name": "Hulk",
+            "owner_name": null,
+            "group_name": null,
+            "risk_type": "Low",
+            "change_type_name": "Minor",
+            "approval_status_name": "Not Requested",
+            "description": "change description",
+            "assoc_release_id": null,
+            "associated_assets": [],
+            "attachments": [],
+            "notes": [],
+            "custom_field_values": {}
+        }
+    },
+    "redirect": null
+}

--- a/freshservice/_testdata/TestUpdateChangeStatus.data
+++ b/freshservice/_testdata/TestUpdateChangeStatus.data
@@ -1,0 +1,51 @@
+{
+    "status": true,
+    "item": {
+        "itil_change": {
+            "id": 1,
+            "display_id": 1,
+            "requester_id": 1,
+            "owner_id": null,
+            "group_id": null,
+            "priority": 1,
+            "impact": 1,
+            "status": %d,
+            "risk": 1,
+            "change_type": 1,
+            "approval_status": 4,
+            "deleted": false,
+            "subject": "change for support",
+            "created_at": "2018-11-01T15:58:49+01:00",
+            "updated_at": "2018-11-01T15:58:49+01:00",
+            "cc_email": {},
+            "planned_start_date": "2018-01-01T01:00:00+01:00",
+            "planned_end_date": "2018-01-01T01:00:00+01:00",
+            "import_id": null,
+            "department_id": null,
+            "email_config_id": null,
+            "project_id": null,
+            "approval_type": null,
+            "wf_event_id": null,
+            "state_flow_id": null,
+            "state_traversal": [
+                1
+            ],
+            "status_name": "Open",
+            "impact_name": "Low",
+            "priority_name": "Low",
+            "requester_name": "Hulk",
+            "owner_name": null,
+            "group_name": null,
+            "risk_type": "Low",
+            "change_type_name": "Minor",
+            "approval_status_name": "Not Requested",
+            "description": "change description",
+            "assoc_release_id": null,
+            "associated_assets": [],
+            "attachments": [],
+            "notes": [],
+            "custom_field_values": {}
+        }
+    },
+    "redirect": null
+}


### PR DESCRIPTION
I've moved some hardcoded strings from the tests into files named `<testName>.data`.

This should make reading tests easier.

Ref: [Golden files](https://www.youtube.com/watch?v=8hQG7QlcLBk)